### PR TITLE
Update strftime to timestamp in token generation.

### DIFF
--- a/conduit/apps/authentication/models.py
+++ b/conduit/apps/authentication/models.py
@@ -133,7 +133,7 @@ class User(AbstractBaseUser, PermissionsMixin, TimestampedModel):
 
         token = jwt.encode({
             'id': self.pk,
-            'exp': int(dt.strftime('%s'))
+            'exp': int(dt.timestamp())
         }, settings.SECRET_KEY, algorithm='HS256')
 
         return token.decode('utf-8')


### PR DESCRIPTION
`dt.strftime('%s')` doesn't work on Windows systems (`ValueError: Invalid format string`) due to `%s` being a Unix-based system only compatible string format for datetimes. 

Using `timestamp` introduced in Python 3.3 is compatible with Unix and Windows-based systems and functional for the project and when using it later for connecting it to a front-end (the other real-world example projects based on Conduit).