### PR TITLE
Fix non-standard strftime() call

### DIFF
--- a/conduit/apps/authentication/models.py
+++ b/conduit/apps/authentication/models.py
@@ -133,7 +133,7 @@ class User(AbstractBaseUser, PermissionsMixin, TimestampedModel):
 
         token = jwt.encode({
             'id': self.pk,
-            'exp': int(dt.strftime('%s'))
+            'exp': int(dt.timestamp())
         }, settings.SECRET_KEY, algorithm='HS256')
 
         return token.decode('utf-8')


### PR DESCRIPTION
The `%s` format string is non-standard for `strftime()` (see [Python docs](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior) and [cpp reference](http://en.cppreference.com/w/c/chrono/strftime)), which causes this sample to fail on some platforms - notably Windows.

Python includes a [`timestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp) method to produce the value you want here (as a float, so the conversion is still necessary).